### PR TITLE
updated url for google fonts in the sript tag

### DIFF
--- a/views/partials/head.ejs
+++ b/views/partials/head.ejs
@@ -28,4 +28,4 @@
   <link rel="stylesheet" type="text/css" href="css/main.css">
 
 <%# Google Font %>
-  <link href='http://fonts.googleapis.com/css?family=Shadows+Into+Light' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Shadows+Into+Light' rel='stylesheet' type='text/css'>


### PR DESCRIPTION
should fix the load of fonts in heroku
