### PR TITLE
fix google maps geocoding malfunction and clickthrough link bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,14 +76,14 @@ function sendTweets(socket, tweet, color){
 
 function load_disconnect_function(socket, stream){
   socket.on('disconnect', function(){
-    console.log("DESTROYED MWAHAHAHAHHAHHAHAHAHAH");
+    // console.log("DESTROYED MWAHAHAHAHHAHHAHAHAHAH");
     stream.destroy();
   });
 }
 
 function load_new_search_function(socket, stream) {
   socket.on('newSearch', function(){
-    console.log("stream is closin...");
+    // console.log("stream is closin...");
     // socket.emit('hideToast');
     stream.destroy();
   });
@@ -91,12 +91,12 @@ function load_new_search_function(socket, stream) {
 
 function load_error_function(socket, stream) {
   stream.on('error', function(error){
-    console.log(error);
+    // console.log(error);
     if(error instanceof TypeError) {
-      console.error("SWALLOWING THE FOLLOWING ERROR! YOLO.");
-      console.trace(error);
+      // console.error("SWALLOWING THE FOLLOWING ERROR! YOLO.");
+      // console.trace(error);
     } else {
-      console.log(error);
+      // console.log(error);
       socket.emit('openModal');
     }
   });

--- a/public/javascript/map_helper.js
+++ b/public/javascript/map_helper.js
@@ -3,7 +3,6 @@
   this.markers = [];
 
   function makeMarker(coordinateArray, map, tweet, color, user, id){
-
     var marker = new google.maps.Marker({
       position: { lat: coordinateArray[0], lng: coordinateArray[1] },
       map: map,
@@ -71,13 +70,12 @@
       if (status == google.maps.GeocoderStatus.OK){
         //take first set of coordinates returned.
         var location = results[0].geometry.location
-        var lat = location.G
-        var lng = location.K
+        var lat = location.lat()
+        var lng = location.lng()
         callback([lat, lng]);
       }
     });
   };
-
   this.geocoding = geocoding;
 
   function initializeMap(){

--- a/public/javascript/socket_helper.js
+++ b/public/javascript/socket_helper.js
@@ -6,7 +6,7 @@ function Socket(){
 Socket.prototype.makeMarkerFromTweet = function(map){
   this.socket.on('tweet', function(data){
     // $(".toast").hide();
-    makeMarker(data.coordinates, map, data.tweet, data.color, data.url, data.user, data.id);
+    makeMarker(data.coordinates, map, data.tweet, data.color,data.user, data.id);
   });
 }
 
@@ -18,7 +18,7 @@ Socket.prototype.performNewSearch = function(searchWord){
 Socket.prototype.listenForGeocode = function(map){
   this.socket.on('geocoder', function(data){
     var address = data.location
-    if (address !== ""){
+    if (address !== null){
       setTimeout(function(){
         geocoding(address, function(latLng) {
           makeMarker(latLng, map, data.tweet, data.color, data.user, data.id);


### PR DESCRIPTION
Geocoding was broken due to a change in the Google Maps geocoding api: in our "geocoding" function we were accessing latitude and longitude using "location.G" and "location.K", but the api (thankfully) replaced those attributes with "lat()" and "lng()" functions. I updated the function to reflect the change and geocoding worked.

In addition, clicking on a marker to get to the tweet was broken. Even before graduation it was only working sometimes, but recently it stopped working altogether. This was because in the two times we called makeMarker, one of the times we called it with six arguments instead of five, and the extra argument was messing up what got defined as username and tweet id. The reason it stopped working altogether was because the time it was called correctly was inside the geocoding function. I fixed the time it was called wrong and now we're good to go!
